### PR TITLE
[Fixup] Don't display page navigator if only single post is present

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,21 +6,23 @@ layout: default
   <time datetime="{{ post.date | date: '%Y-%m-%d' }}">{{ page.date | date: '%a, %b %-d, %Y' }}</time>
   <span>{%- include read-time.html -%}</span>
 </div>
-  
+
 <article>
   <h1>{{ page.title }}</h1>
   {{ content }}
 </article>
 
+{%- if page.previous.url or page.next.url -%}
 <div class="post-nav">
   <span>
-    {%- if page.previous.url -%} 
+    {%- if page.previous.url -%}
     <a href="{{ page.previous.url | prepend: site.baseurl | prepend: site.url }}" class="post-nav__prev" title="{{ page.previous.title }}">← Prev</a>
     {%- endif -%}
   </span>
   <span>
-    {%- if page.next.url -%}  
+    {%- if page.next.url -%}
     <a href="{{ page.next.url | prepend: site.baseurl | prepend: site.url }}" class="post-nav__next" title="{{ page.next.title }}">Next →</a>
-    {%- endif -%} 
+    {%- endif -%}
   </span>
 </div>
+{%- endif -%}


### PR DESCRIPTION
A weird line is shown if single post is present in the `_posts`. This PR removes the whole navigation bar if only single post is present in the blog.